### PR TITLE
First fully functional pipeline with dynamically generated resources

### DIFF
--- a/-inputs.tf
+++ b/-inputs.tf
@@ -1,0 +1,94 @@
+variable "codedeploy_deployment_group_name" {
+  description = "Name of this service's deployment group."
+  type        = string
+}
+
+variable "cp_resource_bucket_arn" {
+  type        = string
+  description = "ARN of the S3 bucket where the source artifacts will be kept."
+}
+
+variable "cp_resource_bucket_name" {
+  type        = string
+  description = "Name of the S3 bucket where the source artifacts will be kept."
+}
+
+variable "cp_resource_bucket_key_name" {
+  type        = string
+  description = "Prefix and key of the source artifact file. For instance, `source/master.zip`."
+}
+
+variable "create" {
+  description = "Conditionally create resources. Affects nearly all resources."
+  type        = bool
+  default     = true
+}
+
+variable "ecr_arn" {
+  description = "ARN of ECR where application container image is kept."
+  type        = string
+}
+
+variable "ecr_name" {
+  description = "Name of ECR where application container image is kept."
+  type        = string
+}
+
+variable "ecr_tag" {
+  description = "Tag of application container image to deploy."
+  type        = string
+}
+
+variable "ecs_service_name" {
+  description = "Name of the ECS Service being deployed"
+  type        = string
+}
+
+variable "input_tags" {
+  description = "Map of tags to apply to all taggable resources."
+  type        = map(string)
+  default = {
+    Provisioner = "Terraform"
+  }
+}
+
+variable "name" {
+  type        = string
+  default     = "codepipline-module"
+  description = "Name to prepend to all resource names within module."
+}
+
+variable "log_retention_days" {
+  description = "Number of days to retain logs for. Configured on Log Group which all log streams are put under."
+  type        = number
+}
+
+
+variable "workload_accounts" {
+  description = "Map of workload accounts, assumable IAM roles in them, and their order of execution in CodePipeline."
+  type = map(object(
+    {
+      account_id      = string
+      manual_approval = bool
+      order           = number
+      service_map     = map(map(string))
+    }
+  ))
+}
+
+variable "vpc_id" {
+  description = "VPC which all resources will be put into"
+  type        = string
+}
+
+#variable "cd_accounts_map" {
+#  type        = map(object(
+#    {
+#      account_id      = string
+#      iam_role        = string
+#      manual_approval = bool
+#      order           = number
+#    }
+#  ))
+#  description = "Map of environments, IAM assumption roles, AWS accounts to create pipeline stages for."
+#}

--- a/-outputs.tf
+++ b/-outputs.tf
@@ -1,0 +1,3 @@
+output "workload_accounts" {
+  value = var.workload_accounts
+}

--- a/-tags.tf
+++ b/-tags.tf
@@ -1,0 +1,5 @@
+locals {
+  common_tags = merge(var.input_tags, {
+    "ModuleSourceRepo" = "github.com/StratusGrid/terraform-aws-multiaccount-application-pipeline"
+  })
+}

--- a/.gitignore
+++ b/.gitignore
@@ -5,25 +5,14 @@
 *.tfstate
 *.tfstate.*
 
-# Crash log files
-crash.log
+# .tfvars files
+#*.tfvars
 
-# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
-# .tfvars files are managed as part of configuration and so should be included in
-# version control.
-#
-# example.tfvars
+# IDE temp files
+**/.idea/*
 
-# Ignore override files as they are usually used to override resources locally and so
-# are not checked in
-override.tf
-override.tf.json
-*_override.tf
-*_override.tf.json
-
-# Include override files you do wish to add to version control using negated pattern
-#
-# !example_override.tf
+# MacOS files
+.DS_Store
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*

--- a/IAM-POLICY.md
+++ b/IAM-POLICY.md
@@ -1,0 +1,50 @@
+Below is an example policy of what to add to thge child accounts for the multi account pipeline to assume and have the correct permissions to acomplish it's role.
+
+```hcl
+data "aws_iam_policy_document" "this" {
+  statement {
+    sid = "AllowFullAdminExceptSomeWithMFA"
+    not_actions = [
+      "logs:Delete*",
+      "cloudtrail:Delete*",
+      "cloudtrail:Stop*",
+      "cloudtrail:Update*",
+      "sts:AssumeRoleWithSAML",
+      "sts:AssumeRoleWithWebIdentity",
+      "sts:GetFederationToken",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "cicd" {
+  name        = "CICD-policy"
+  description = "Policy to grant restricted admin. This admin can't do some functions such as delete the CloudTrail audit trail."
+  policy      = data.aws_iam_policy_document.this.json
+}
+
+
+module "iam_role_cicd" {
+  source = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+
+  trusted_role_arns = [
+    "arn:aws:iam::467176576189:root" # Root means account and not root user
+  ]
+
+  create_role = true
+
+  role_name         = "${var.name_prefix}-pipeline-role-CICD" #The assuming account matches it based upon name
+  role_requires_mfa = false
+
+  custom_role_policy_arns = [
+    //aws_iam_role_policy.codepipeline_deploy_policy.arn
+    aws_iam_policy.cicd.arn
+  ]
+
+  tags = {
+    "Name" = "${var.name_prefix}-pipeline-role-CICD${local.name_suffix}"
+  }
+}
+```

--- a/codepipeline-multiaccount.tf
+++ b/codepipeline-multiaccount.tf
@@ -1,0 +1,173 @@
+#data "aws_kms_alias" "s3" {
+#  name = "alias/aws/s3"
+#}
+
+resource "aws_codepipeline" "codepipeline_application" {
+  count    = var.create ? 1 : 0
+  name     = "${var.name}-pipeline"
+  role_arn = join("", aws_iam_role.codepipeline_role.*.arn)
+
+  artifact_store {
+    location = one(distinct(flatten([for account in var.workload_accounts : [for service in account["service_map"] : service.artifact_bucket]])))
+    type     = "S3"
+    encryption_key {
+      id   = one(distinct(flatten([for account in var.workload_accounts : [for service in account["service_map"] : service.artifact_kms_key_arn]])))
+      type = "KMS"
+    }
+  }
+  tags = merge(
+    local.common_tags,
+    {
+      "Name" = "${var.name}-cp-terraform"
+    },
+  )
+
+  stage {
+    name = "Source"
+
+    action {
+      owner            = "AWS"
+      name             = "ArtifactsECR"
+      category         = "Source"
+      provider         = "ECR"
+      version          = "1"
+      output_artifacts = ["ArtifactsECR"]
+
+      configuration = {
+        RepositoryName = var.ecr_name
+        ImageTag       = var.ecr_tag
+      }
+    }
+
+    dynamic "action" {
+      for_each = flatten([for account in var.workload_accounts : [for service_map in account["service_map"] : service_map]])
+      content {
+        owner            = "AWS"
+        name             = "ArtifactsS3-${action.value["codedeploy_deployment_app_name"]}"
+        category         = "Source"
+        provider         = "S3"
+        version          = "1"
+        output_artifacts = ["ArtifactsS3-${action.value["codedeploy_deployment_app_name"]}"]
+
+        configuration = {
+          PollForSourceChanges = "false"
+          S3Bucket             = action.value["artifact_bucket"]
+          S3ObjectKey          = action.value["artifact_key"]
+        }
+      }
+    }
+  }
+
+  stage {
+    name = "Deploy_to_DEV"
+
+    dynamic "action" {
+      for_each = [for service in var.workload_accounts["dev"]["service_map"] : service]
+
+      content {
+        name            = "Deploy_${action.value["codedeploy_deployment_app_name"]}_to_DEV"
+        category        = "Deploy"
+        owner           = "AWS"
+        provider        = "CodeDeployToECS"
+        version         = "1"
+        input_artifacts = ["ArtifactsECR", "ArtifactsS3-${action.value["codedeploy_deployment_app_name"]}"]
+        run_order       = 1
+        role_arn        = action.value["trusting_account_role"]
+
+        configuration = {
+          AppSpecTemplateArtifact        = "ArtifactsS3-${action.value["codedeploy_deployment_app_name"]}"
+          ApplicationName                = action.value["codedeploy_deployment_app_name"]
+          DeploymentGroupName            = action.value["codedeploy_deployment_group_name"]
+          Image1ArtifactName             = "ArtifactsECR"
+          Image1ContainerName            = "IMAGE1_NAME"
+          TaskDefinitionTemplateArtifact = "ArtifactsS3-${action.value["codedeploy_deployment_app_name"]}"
+          AppSpecTemplatePath            = "appspec.yaml"
+          TaskDefinitionTemplatePath     = "taskdef.json"
+        }
+      }
+    }
+
+    action {
+      category  = "Approval"
+      name      = "Approve_Deployment_to_QA"
+      owner     = "AWS"
+      provider  = "Manual"
+      version   = "1"
+      run_order = 2
+    }
+  }
+
+  stage {
+    name = "Deploy_to_QA_and_PRD"
+
+    dynamic "action" {
+      for_each = [for service in var.workload_accounts["qa"]["service_map"] : service]
+
+      content {
+        name            = "Deploy_${action.value["codedeploy_deployment_app_name"]}_to_QA"
+        category        = "Deploy"
+        owner           = "AWS"
+        provider        = "CodeDeployToECS"
+        version         = "1"
+        input_artifacts = ["ArtifactsECR", "ArtifactsS3-${action.value["codedeploy_deployment_app_name"]}"]
+        run_order       = 1
+        role_arn        = action.value["trusting_account_role"]
+
+        configuration = {
+          AppSpecTemplateArtifact        = "ArtifactsS3-${action.value["codedeploy_deployment_app_name"]}"
+          ApplicationName                = action.value["codedeploy_deployment_app_name"]
+          DeploymentGroupName            = action.value["codedeploy_deployment_group_name"]
+          Image1ArtifactName             = "ArtifactsECR"
+          Image1ContainerName            = "IMAGE1_NAME"
+          TaskDefinitionTemplateArtifact = "ArtifactsS3-${action.value["codedeploy_deployment_app_name"]}"
+          AppSpecTemplatePath            = "appspec.yaml"
+          TaskDefinitionTemplatePath     = "taskdef.json"
+        }
+      }
+    }
+
+    action {
+      category  = "Approval"
+      name      = "Approve_Deployment_to_PRD"
+      owner     = "AWS"
+      provider  = "Manual"
+      version   = "1"
+      run_order = 2
+    }
+
+    dynamic "action" {
+      for_each = [for service in var.workload_accounts["prd"]["service_map"] : service]
+
+      content {
+        name            = "Deploy_${action.value["codedeploy_deployment_app_name"]}_to_PRD"
+        category        = "Deploy"
+        owner           = "AWS"
+        provider        = "CodeDeployToECS"
+        version         = "1"
+        input_artifacts = ["ArtifactsECR", "ArtifactsS3-${action.value["codedeploy_deployment_app_name"]}"]
+        run_order       = 3
+        role_arn        = action.value["trusting_account_role"]
+
+        configuration = {
+          AppSpecTemplateArtifact        = "ArtifactsS3-${action.value["codedeploy_deployment_app_name"]}"
+          ApplicationName                = action.value["codedeploy_deployment_app_name"]
+          DeploymentGroupName            = action.value["codedeploy_deployment_group_name"]
+          Image1ArtifactName             = "ArtifactsECR"
+          Image1ContainerName            = "IMAGE1_NAME"
+          TaskDefinitionTemplateArtifact = "ArtifactsS3-${action.value["codedeploy_deployment_app_name"]}"
+          AppSpecTemplatePath            = "appspec.yaml"
+          TaskDefinitionTemplatePath     = "taskdef.json"
+        }
+      }
+    }
+
+    action {
+      category  = "Approval"
+      name      = "Production_Deployment_Acceptance"
+      owner     = "AWS"
+      provider  = "Manual"
+      version   = "1"
+      run_order = 4
+    }
+  }
+}

--- a/iam-roles-policies.tf
+++ b/iam-roles-policies.tf
@@ -1,0 +1,118 @@
+### CODEPIPELINE TERRAFORM IAM ROLE ###
+resource "aws_iam_role" "codepipeline_role" {
+  count = var.create ? 1 : 0
+  name  = "${var.name}-codepipeline"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ServiceRoleAssumption"
+        Effect = "Allow"
+        Action = "sts:AssumeRole"
+        Principal = {
+          Service = "codepipeline.amazonaws.com"
+        }
+      },
+    ]
+  })
+
+  tags = merge(var.input_tags, {})
+}
+
+data "aws_iam_policy_document" "codepipeline_workload_assume_policy" {
+  dynamic "statement" {
+    for_each = var.workload_accounts
+    content {
+      actions   = ["sts:AssumeRole"]
+      effect    = "Allow"
+      resources = flatten([for service in statement.value.service_map : service.trusting_account_role])
+    }
+  }
+}
+
+data "aws_iam_policy_document" "codepipeline_artifact_bucket_policy" {
+  dynamic "statement" {
+    for_each = var.workload_accounts
+    content {
+      #      sid = "ArtifactBucketAccess"
+
+      actions = [
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "s3:GetBucketVersioning",
+        "s3:PutObject",
+        "s3:PutObjectAcl"
+      ]
+
+      resources = concat(
+        distinct([for service in statement.value.service_map : "arn:aws:s3:::${service.artifact_bucket}"]),
+        distinct([for service in statement.value.service_map : "arn:aws:s3:::${service.artifact_bucket}/*"])
+      )
+    }
+  }
+
+  statement {
+    sid = "PipelineECRAccess"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
+      "ecr:DescribeImages",
+      "ecr:GetAuthorizationToken",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:ListImages"
+    ]
+    resources = [
+      var.ecr_arn
+    ]
+  }
+
+  # This is used for encrypting artifacts
+  dynamic "statement" {
+    for_each = var.workload_accounts
+    content {
+      #      sid = "ArtifactBucketKMSKeyAccess"
+
+      actions = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey"
+      ]
+
+      resources = concat(
+        distinct([for service in statement.value.service_map : service.artifact_kms_key_arn])
+      )
+    }
+  }
+
+  statement {
+    sid = "CodeDeployAccess"
+
+    actions = [
+      "codedeploy:CreateDeployment",
+      "codedeploy:GetApplication",
+      "codedeploy:GetApplicationRevision",
+      "codedeploy:GetDeployment",
+      "codedeploy:GetDeploymentConfig",
+      "codedeploy:RegisterApplicationRevision"
+    ]
+
+    resources = ["*"]
+  }
+
+}
+
+resource "aws_iam_role_policy" "codepipeline_policy" {
+  count  = var.create ? 1 : 0
+  name   = "${var.name}-codepipeline-policy"
+  role   = join("", aws_iam_role.codepipeline_role.*.id)
+  policy = data.aws_iam_policy_document.codepipeline_artifact_bucket_policy.json
+}
+
+resource "aws_iam_role_policy" "codepipeline_policy_account_assume" {
+  count  = var.create ? 1 : 0
+  name   = "${var.name}-codepipeline-account-assume-policy"
+  role   = join("", aws_iam_role.codepipeline_role.*.id)
+  policy = data.aws_iam_policy_document.codepipeline_workload_assume_policy.json
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.74"
+    }
+  }
+}


### PR DESCRIPTION
feature: add KMS Key for pipeline artifacts
feature: add output to show all mapped services
feature: add parameter for workload account mappings
feature: add parameters for values output by the workload infrastructure
feature: dynamically include all trusting (assumable) IAM roles in the CodePipeline role
feature: initial codepipeline
feature: stamp out basic pipeline role/policy
feature: update pipeline to include PRD deployment & manual approvals
feature: update pipeline to resolve artifacts from service map
feature: update roles and policy to allow proper assumptions and rights
fix: KMS key for CICD bucket moved out of module - this must be at the account level
fix: correct the way mapped value is used
fix: define KMS CMK in CodePipeline configuration, which is used by resources in the workload accounts to get/put S3 objects
fix: for now, remove SID entries to avoid duplicates and hard-code QA stage
refactor: CodePipeline artifact store configuration now derived from service map
refactor: clean up inputs
refactor: coalesced bucket access policies in CodePipeline IAM
refactor: code formatting
refactor: codepipeline artifact bucket access dynamically built, allowing services/pipelines to potentially use different artifact buckets
refactor: kms key now retrieved from service map

## Change description

> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
